### PR TITLE
Feature: Migrate User and Auth Endpoints to Hexagonal Arquitecture

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,4 @@ WORKDIR /code
 COPY ./requirements.txt /code/requirements.txt
 RUN pip install --no-cache-dir --upgrade -r /code/requirements.txt
 COPY ./esturide_api /code/app
-CMD ["uvicorn", "esturide_api.main:app", "--host", "0.0.0.0", "--port", "80", "--reload"]
+CMD ["uvicorn", "esturide_api.app.main:app", "--host", "0.0.0.0", "--port", "80", "--reload"]

--- a/esturide_api/app/main.py
+++ b/esturide_api/app/main.py
@@ -2,11 +2,17 @@ from fastapi import FastAPI
 
 from esturide_api import models
 from esturide_api.config.database import engine
+from esturide_api.contexts.user.infraestructure.router.user_router import (
+    router as V2_UserRouter,
+)
 from esturide_api.routers.auth import router as AuthorizationRouter
 from esturide_api.routers.automobile import router as AutomobileRouter
 from esturide_api.routers.drivers import router as DriverRouter
 from esturide_api.routers.populate_db import router as DBRouter
 from esturide_api.routers.user import router as UserRouter
+from esturide_api.shared.authentication.infraestructure.router.authentication_router import (
+    router as V2_AuthorizationRouter,
+)
 
 models.Base.metadata.create_all(bind=engine)
 app = FastAPI()
@@ -16,6 +22,8 @@ app.include_router(AuthorizationRouter)
 app.include_router(DriverRouter)
 app.include_router(AutomobileRouter)
 app.include_router(DBRouter)
+app.include_router(V2_UserRouter)
+app.include_router(V2_AuthorizationRouter)
 
 
 @app.get("/")

--- a/esturide_api/contexts/user/application/user_service.py
+++ b/esturide_api/contexts/user/application/user_service.py
@@ -1,0 +1,18 @@
+from typing import List
+
+from esturide_api.contexts.user.domain.model.user_model import UserOut
+from esturide_api.contexts.user.domain.service.user_domain_service import UserService
+
+
+class UserApplicationService:
+    def __init__(self, user_service: UserService):
+        self.user_service = user_service
+
+    def get_user(
+        self,
+        user_id: int,
+    ) -> UserOut:
+        return self.user_service.get_user(user_id)
+
+    def get_users(self) -> List[UserOut]:
+        return self.user_service.get_users()

--- a/esturide_api/contexts/user/depencencies.py
+++ b/esturide_api/contexts/user/depencencies.py
@@ -1,0 +1,20 @@
+from fastapi import Depends
+from sqlalchemy.orm import Session
+
+from esturide_api.config.database import get_db
+from esturide_api.contexts.user.application.user_service import UserApplicationService
+from esturide_api.contexts.user.domain.repository.user_repository import UserRepository
+from esturide_api.contexts.user.domain.service.user_domain_service import UserService
+from esturide_api.contexts.user.infraestructure.database.db_user_repository import (
+    UserPostgresRepository,
+)
+
+
+def get_user_repository(db: Session = Depends(get_db)):
+    return UserPostgresRepository(db)
+
+
+def get_user_application_service(
+    user_repository: UserRepository = Depends(get_user_repository),
+) -> UserApplicationService:
+    return UserApplicationService(UserService(user_repository))

--- a/esturide_api/contexts/user/domain/model/user_model.py
+++ b/esturide_api/contexts/user/domain/model/user_model.py
@@ -1,0 +1,62 @@
+from datetime import date, timedelta
+from typing import Optional
+
+from pydantic import BaseModel, EmailStr, validator
+
+
+class UserBase(BaseModel):
+    firstname: str
+    maternal_surname: str
+    paternal_surname: str
+    password: str
+    birth_date: date
+    school_code: str
+    email: EmailStr
+    curp: str
+
+
+class UserCreate(UserBase):
+    @validator("birth_date")
+    def validate_birth_date(cls, value: date):
+        today = date.today()
+        minimum_age = today - timedelta(days=365 * 16)
+        if value > minimum_age:
+            raise ValueError("The person must be of legal age")
+        return value
+
+
+class UserUpdatePut(BaseModel):
+    email: EmailStr
+    firstname: str
+    maternal_surname: str
+    paternal_surname: str
+    curp: str
+    birth_date: date
+
+
+class UserUpdatePatch(BaseModel):
+    email: Optional[EmailStr] = None
+    firstname: Optional[str] = None
+    maternal_surname: Optional[str] = None
+    paternal_surname: Optional[str] = None
+    curp: Optional[str] = None
+    birth_date: Optional[date] = None
+
+
+class UserLogin(BaseModel):
+    email: EmailStr
+    password: str
+
+
+class UserOut(BaseModel):
+    id: int
+    email: EmailStr
+    firstname: str
+    maternal_surname: str
+    paternal_surname: str
+    curp: str
+    valid_user: bool
+
+    class Config:
+        from_attributes = True
+        orm_mode = True

--- a/esturide_api/contexts/user/domain/repository/user_repository.py
+++ b/esturide_api/contexts/user/domain/repository/user_repository.py
@@ -1,0 +1,16 @@
+from abc import ABC, abstractmethod
+from typing import List
+
+
+class UserRepository(ABC):
+    @abstractmethod
+    def get_user_by_id(self, id: int) -> dict:
+        pass
+
+    @abstractmethod
+    def get_user_by_email(self, email: str) -> dict:
+        pass
+
+    @abstractmethod
+    def get_all_users(self) -> List[dict]:
+        pass

--- a/esturide_api/contexts/user/domain/service/user_domain_service.py
+++ b/esturide_api/contexts/user/domain/service/user_domain_service.py
@@ -1,0 +1,15 @@
+from typing import List
+
+from esturide_api.contexts.user.domain.model.user_model import UserOut
+from esturide_api.contexts.user.domain.repository.user_repository import UserRepository
+
+
+class UserService:
+    def __init__(self, user_repository: UserRepository):
+        self.user_repository = user_repository
+
+    def get_user(self, user_id: int) -> UserOut:
+        return self.user_repository.get_user_by_id(user_id)
+
+    def get_users(self) -> List[UserOut]:
+        return self.user_repository.get_all_users()

--- a/esturide_api/contexts/user/infraestructure/database/db_user_repository.py
+++ b/esturide_api/contexts/user/infraestructure/database/db_user_repository.py
@@ -1,0 +1,20 @@
+from typing import List
+
+from sqlalchemy.orm import Session
+
+from esturide_api import models
+from esturide_api.contexts.user.domain.repository.user_repository import UserRepository
+
+
+class UserPostgresRepository(UserRepository):
+    def __init__(self, db: Session):
+        self.db = db
+
+    def get_user_by_id(self, id: int) -> dict:
+        return self.db.query(models.User).filter(models.User.id == id).first()
+
+    def get_user_by_email(self, email: str) -> dict:
+        return self.db.query(models.User).filter(models.User.email == email).first()
+
+    def get_all_users(self) -> List[dict]:
+        return self.db.query(models.User).all()

--- a/esturide_api/contexts/user/infraestructure/router/user_router.py
+++ b/esturide_api/contexts/user/infraestructure/router/user_router.py
@@ -16,7 +16,6 @@ def get_user(
     user_app_service: UserApplicationService = Depends(get_user_application_service),
     current_user=Depends(get_request_user),
 ):
-    print(current_user)
     return user_app_service.get_user(id)
 
 
@@ -25,5 +24,4 @@ def get_users(
     user_app_service: UserApplicationService = Depends(get_user_application_service),
     current_user=Depends(get_request_user),
 ):
-    print(current_user)
     return user_app_service.get_users()

--- a/esturide_api/contexts/user/infraestructure/router/user_router.py
+++ b/esturide_api/contexts/user/infraestructure/router/user_router.py
@@ -1,0 +1,29 @@
+from typing import List
+
+from fastapi import APIRouter, Depends
+
+from esturide_api.contexts.user.application.user_service import UserApplicationService
+from esturide_api.contexts.user.depencencies import get_user_application_service
+from esturide_api.contexts.user.domain.model.user_model import UserOut
+from esturide_api.shared.authentication.dependencies import get_request_user
+
+router = APIRouter(prefix="/v2/users", tags=["Users"])
+
+
+@router.get("/{id}", response_model=UserOut)
+def get_user(
+    id: int,
+    user_app_service: UserApplicationService = Depends(get_user_application_service),
+    current_user=Depends(get_request_user),
+):
+    print(current_user)
+    return user_app_service.get_user(id)
+
+
+@router.get("/", response_model=List[UserOut])
+def get_users(
+    user_app_service: UserApplicationService = Depends(get_user_application_service),
+    current_user=Depends(get_request_user),
+):
+    print(current_user)
+    return user_app_service.get_users()

--- a/esturide_api/shared/authentication/application/authentication_service.py
+++ b/esturide_api/shared/authentication/application/authentication_service.py
@@ -1,0 +1,16 @@
+from esturide_api.contexts.user.domain.model.user_model import UserOut
+from esturide_api.shared.authentication.domain.service.authentication_domain_service import (
+    AuthenticationService,
+)
+
+
+class AuthenticationApplicationService:
+    def __init__(self, auth_service: AuthenticationService):
+        self.auth_service = auth_service
+
+    def authenticate_user(self, user_credentials) -> dict:
+        user_id = self.auth_service.authenticate_user(user_credentials)
+        return self.auth_service.generate_token(user_id)
+
+    def get_request_user(self, token: str) -> UserOut:
+        return self.auth_service.verify_access_token(token)

--- a/esturide_api/shared/authentication/dependencies.py
+++ b/esturide_api/shared/authentication/dependencies.py
@@ -1,0 +1,41 @@
+from fastapi import Depends
+from fastapi.security import OAuth2PasswordBearer
+from sqlalchemy.orm import Session
+
+from esturide_api.config.database import get_db
+from esturide_api.contexts.user.domain.model.user_model import UserOut
+from esturide_api.contexts.user.domain.repository.user_repository import UserRepository
+from esturide_api.contexts.user.infraestructure.database.db_user_repository import (
+    UserPostgresRepository,
+)
+from esturide_api.shared.authentication.application.authentication_service import (
+    AuthenticationApplicationService,
+)
+from esturide_api.shared.authentication.domain.service.authentication_domain_service import (
+    AuthenticationService,
+)
+from esturide_api.shared.authentication.infraestructure.oauth import PasswordHandler
+
+
+def get_user_repository(db: Session = Depends(get_db)):
+    return UserPostgresRepository(db)
+
+
+def get_authentication_application_service(
+    user_repository: UserRepository = Depends(get_user_repository),
+) -> AuthenticationApplicationService:
+    return AuthenticationApplicationService(
+        AuthenticationService(
+            user_repository,
+            PasswordHandler(),
+        ),
+    )
+
+
+def get_request_user(
+    token: OAuth2PasswordBearer = Depends(OAuth2PasswordBearer(tokenUrl="v2/login")),
+    authentication_service: AuthenticationApplicationService = Depends(
+        get_authentication_application_service
+    ),
+) -> UserOut:
+    return authentication_service.get_request_user(token)

--- a/esturide_api/shared/authentication/domain/model/authentication_model.py
+++ b/esturide_api/shared/authentication/domain/model/authentication_model.py
@@ -1,0 +1,8 @@
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class Token(BaseModel):
+    access_token: str
+    token_type: Optional[str] = "bearer"

--- a/esturide_api/shared/authentication/domain/service/authentication_domain_service.py
+++ b/esturide_api/shared/authentication/domain/service/authentication_domain_service.py
@@ -1,0 +1,58 @@
+from datetime import datetime, timedelta
+
+from fastapi import HTTPException, status
+from fastapi.security import OAuth2PasswordBearer
+from jose import JWTError, jwt
+
+from esturide_api.config.config import settings
+from esturide_api.contexts.user.domain.model.user_model import UserOut
+from esturide_api.contexts.user.domain.repository.user_repository import UserRepository
+from esturide_api.shared.authentication.infraestructure.oauth import PasswordHandler
+
+SECRET_KEY = settings.secret_key
+ALGORITHM = settings.algorithm
+ACCESS_TOKEN_EXPIRE_MINUTES = settings.access_token_expire_minutes
+
+
+class AuthenticationService:
+    def __init__(
+        self, user_repository: UserRepository, password_handler: PasswordHandler
+    ):
+        self.user_repository = user_repository
+        self.password_handler = password_handler
+
+    def authenticate_user(self, user_credentials) -> int:
+        user = self.user_repository.get_user_by_email(user_credentials.username)
+
+        if not user or not self.password_handler.verify(
+            user_credentials.password, user.password
+        ):
+            self.raise_invalid_credentials_error()
+
+        return user.id
+
+    def generate_token(self, user_id: int) -> dict:
+        expire_time = datetime.utcnow() + timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+        to_encode = {"user_id": user_id, "exp": expire_time}
+        encoded_jwt = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+        return {"access_token": encoded_jwt}
+
+    def verify_access_token(self, token: OAuth2PasswordBearer) -> UserOut:
+        try:
+            payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+            user_id = str(payload.get("user_id"))
+            if user_id is None:
+                raise self.raise_invalid_token_error()
+        except JWTError:
+            raise self.raise_invalid_token_error()
+        return UserOut.from_orm(self.user_repository.get_user_by_id(user_id))
+
+    def raise_invalid_credentials_error(self):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Invalid Credentials"
+        )
+
+    def raise_invalid_token_error(self):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Invalid JWT Token"
+        )

--- a/esturide_api/shared/authentication/infraestructure/oauth.py
+++ b/esturide_api/shared/authentication/infraestructure/oauth.py
@@ -1,0 +1,12 @@
+from passlib.context import CryptContext
+
+
+class PasswordHandler:
+    def __init__(self):
+        self.pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+    def hash(self, password: str):
+        return self.pwd_context.hash(password)
+
+    def verify(self, plain_password, hashed_password):
+        return self.pwd_context.verify(plain_password, hashed_password)

--- a/esturide_api/shared/authentication/infraestructure/router/authentication_router.py
+++ b/esturide_api/shared/authentication/infraestructure/router/authentication_router.py
@@ -1,0 +1,22 @@
+from fastapi import APIRouter, Depends
+from fastapi.security.oauth2 import OAuth2PasswordRequestForm
+
+from esturide_api.shared.authentication.application.authentication_service import (
+    AuthenticationApplicationService,
+)
+from esturide_api.shared.authentication.dependencies import (
+    get_authentication_application_service,
+)
+from esturide_api.shared.authentication.domain.model.authentication_model import Token
+
+router = APIRouter(prefix="/v2", tags=["Authentication"])
+
+
+@router.post("/login", response_model=Token)
+def login(
+    user_credentials: OAuth2PasswordRequestForm = Depends(),
+    authentication_app_service: AuthenticationApplicationService = Depends(
+        get_authentication_application_service
+    ),
+):
+    return authentication_app_service.authenticate_user(user_credentials)


### PR DESCRIPTION
## Associated Task
- [Notion Task Name](Notion Task Link) - Brief description of the task.

## Change Summary
- Migration of the `User` and `Authentication` Endpoints to the Hexagonal Arquitecture
- Migration of the Dependency Injection function `get_request_user` to JWT Endpoint Authentication

## Change Type
Indicate the type of change this pull request represents by checking the appropriate box(es).

- [x] Enhancement - Improves existing functionality or performance.


### Additional Options
- [ ] Requires Database Migration - Check if this change involves database migrations.

## Compliance Checklist
Before submitting, ensure your changes meet the following criteria:

- [x] Code Style - Adheres to the project's coding conventions and guidelines.
- [x] Self-Review - Conducted a thorough self-review to catch potential issues.
- [ ] Documentation - Updated all relevant documentation to reflect the changes.
- [ ] No Warnings - Ensured that changes do not introduce new warnings or errors.
- [ ] Testing - Added or updated tests that validate the changes.
- [ ] Regression - Confirmed that existing functionalities are not adversely affected.
- [ ] Dependencies - Checked that all dependent changes have been addressed and merged.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license.